### PR TITLE
feat/default-values

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Transform data into hydrated objects by [describing](#property-level-cast) how t
 - [Type Casting](#property-level-cast): Supports primitives, custom classes, enums, and more.
 - [Transformations](#transformations): Describe how to resolve a value before instantiation.
 - [Required Properties](#required-properties): Throw an exception when a property is not set.
-
+- [Default Values](#default-values): Set a default property value.
 ## Installation
 
 You can install the package via Composer:
@@ -122,7 +122,8 @@ The `Describe` attribute can accept these arguments.
     'cast' => [MyClass::class, 'methodName'], 
  // alternately target a function
  // 'cast' => 'strtoupper', 
-    'required' => true
+    'required' => true,
+    'default' => 'value'
 ])]
 ```
 
@@ -283,6 +284,26 @@ class User
 
 $user = User::from(['email' => 'john@example.com']);
 // Throws PropertyRequiredException exception: Property: username is required
+```
+
+## Default Values
+
+You can set a default value for a property like this:
+
+```php
+use Zerotoprod\DataModel\Describe;
+
+class User
+{
+    use \Zerotoprod\DataModel\DataModel;
+
+    #[Describe(['default' => 'N/A'])]
+    public string $username;
+}
+
+$user = User::from();
+
+echo $user->username // 'N/A'
 ```
 
 ## Examples

--- a/src/DataModel.php
+++ b/src/DataModel.php
@@ -125,12 +125,8 @@ trait DataModel
      *
      * @param  iterable|object|null  $context  Data to populate the instance.
      */
-    public static function from(iterable|object|null $context = null): self
+    public static function from(iterable|object|null $context = []): self
     {
-        if (!$context) {
-            return new self();
-        }
-
         if ($context instanceof self) {
             return $context;
         }
@@ -207,6 +203,10 @@ trait DataModel
 
             /** When a property name does not match a key name  */
             if (!array_key_exists($property_name, $context)) {
+                if ($Describe->default ?? false) {
+                    $self->{$property_name} = $Describe->default;
+                    continue;
+                }
                 if ($Describe->required ?? false) {
                     throw new PropertyRequiredException("Property: $property_name is required");
                 }

--- a/src/Describe.php
+++ b/src/Describe.php
@@ -104,6 +104,7 @@ class Describe
 {
     public string|array $cast;
     public bool $required;
+    public mixed $default;
 
     /**
      *  Pass an associative array to the constructor to describe the behavior of a property when it is resolved.

--- a/tests/Unit/Describe/Default/BaseClass.php
+++ b/tests/Unit/Describe/Default/BaseClass.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Tests\Unit\Describe\Default;
+
+use Zerotoprod\DataModel\DataModel;
+use Zerotoprod\DataModel\Describe;
+
+class BaseClass
+{
+    use DataModel;
+
+    public const string = 'string';
+
+    #[Describe(['default' => '1'])]
+    public string $string;
+}

--- a/tests/Unit/Describe/Default/ClassTest.php
+++ b/tests/Unit/Describe/Default/ClassTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Tests\Unit\Describe\Default;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class ClassTest extends TestCase
+{
+    #[Test] public function from(): void
+    {
+        $BaseClass = BaseClass::from();
+
+        $this->assertEquals('1', $BaseClass->string);
+    }
+}


### PR DESCRIPTION
## Description
This MR adds support for default values.

```php
use Zerotoprod\DataModel\Describe;

class User
{
    use \Zerotoprod\DataModel\DataModel;

    #[Describe(['default' => 'N/A'])]
    public string $username;
}

$user = User::from();

echo $user->username // 'N/A'
```