### PR TITLE
feat/add-support-for-life-cycle-hooks

### DIFF
--- a/src/DataModel.php
+++ b/src/DataModel.php
@@ -189,9 +189,27 @@ trait DataModel
             $Describe = $Attribute?->newInstance();
             $property_name = $ReflectionProperty->getName();
 
+            /** Property-level Pre Hook */
+            if (isset($Describe->pre)) {
+                ($Describe->pre)($context[$property_name] ?? [], $context, $Attribute, $ReflectionProperty);
+            }
+
             /** Property-level Cast */
             if (isset($Describe->cast) && $context) {
                 $self->{$property_name} = ($Describe->cast)($context[$property_name] ?? [], $context, $Attribute, $ReflectionProperty);
+
+                /** Property-level Post Hook */
+                if (isset($Describe->post)) {
+                    ($Describe->post)($self->{$property_name}, $context, $Attribute, $ReflectionProperty);
+                }
+
+                continue;
+            }
+
+            /** Property-level Post Hook */
+            if (isset($Describe->post)) {
+                $self->{$property_name} = $context[$property_name];
+                ($Describe->post)($self->{$property_name}, $context, $Attribute, $ReflectionProperty);
                 continue;
             }
 

--- a/src/Describe.php
+++ b/src/Describe.php
@@ -105,6 +105,8 @@ class Describe
     public string|array $cast;
     public bool $required;
     public mixed $default;
+    public mixed $pre;
+    public mixed $post;
 
     /**
      *  Pass an associative array to the constructor to describe the behavior of a property when it is resolved.
@@ -193,6 +195,8 @@ class Describe
      *      }
      *  }
      *  ```
+     *
+     * @param  string|array{'pre': string|string[], 'cast': string|string[], 'post': string|string[], 'required': bool, 'default': mixed, ...}|null|  $attributes
      *
      * @link https://github.com/zero-to-prod/data-model
      *

--- a/tests/Unit/Describe/Post/BaseClass.php
+++ b/tests/Unit/Describe/Post/BaseClass.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Unit\Describe\Post;
+
+use ReflectionAttribute;
+use ReflectionProperty;
+use RuntimeException;
+use Zerotoprod\DataModel\DataModel;
+use Zerotoprod\DataModel\Describe;
+
+class BaseClass
+{
+    use DataModel;
+
+    public const int = 'int';
+
+    #[Describe([
+        'cast' => [self::class, 'increment'],
+        'post' => [self::class, 'post'],
+        'message' => 'Value too large.',
+    ])]
+    public int $int;
+
+    public static function increment($value, array $context, ?ReflectionAttribute $ReflectionAttribute, ReflectionProperty $ReflectionProperty): int
+    {
+       return ++$value;
+    }
+
+    public static function post($value, array $context, ?ReflectionAttribute $ReflectionAttribute, ReflectionProperty $ReflectionProperty): void
+    {
+        if ($value > 10) {
+            throw new RuntimeException($value.$ReflectionAttribute->getArguments()[0]['message']);
+        }
+    }
+}

--- a/tests/Unit/Describe/Post/PostTest.php
+++ b/tests/Unit/Describe/Post/PostTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Unit\Describe\Post;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class
+PostTest extends TestCase
+{
+    #[Test] public function from(): void
+    {
+        $this->expectExceptionMessage('Value too large.');
+
+        BaseClass::from([
+            BaseClass::int => 100,
+        ]);
+    }
+
+    #[Test] public function does_not_throw_exception(): void
+    {
+        $BaseClass = BaseClass::from([
+            BaseClass::int => 1,
+        ]);
+
+        self::assertEquals(2, $BaseClass->int);
+    }
+}

--- a/tests/Unit/Examples/Post/BaseClass.php
+++ b/tests/Unit/Examples/Post/BaseClass.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\Unit\Examples\Post;
+
+use Zerotoprod\DataModel\Describe;
+
+class BaseClass
+{
+    use \Zerotoprod\DataModel\DataModel;
+
+    public const int = 'int';
+
+    #[Describe([
+        'post' => [self::class, 'post'],
+        'message' => 'Value too large.',
+    ])]
+    public int $int;
+
+    public static function post($value, array $context, ?\ReflectionAttribute $Attribute, \ReflectionProperty $Property): void
+    {
+        if ($value > 10) {
+            throw new \RuntimeException($value.$Attribute->getArguments()[0]['message']);
+        }
+    }
+}

--- a/tests/Unit/Examples/Post/PostTest.php
+++ b/tests/Unit/Examples/Post/PostTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Unit\Examples\Post;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class
+PostTest extends TestCase
+{
+    #[Test] public function from(): void
+    {
+        $this->expectExceptionMessage('Value too large.');
+
+        BaseClass::from([
+            BaseClass::int => 100,
+        ]);
+    }
+
+    #[Test] public function does_not_throw_exception(): void
+    {
+        $BaseClass = BaseClass::from([
+            BaseClass::int => 1,
+        ]);
+
+        self::assertEquals(1, $BaseClass->int);
+    }
+}

--- a/tests/Unit/Examples/Pre/BaseClass.php
+++ b/tests/Unit/Examples/Pre/BaseClass.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests\Unit\Examples\Pre;
+
+use Zerotoprod\DataModel\Describe;
+
+class BaseClass
+{
+    use \Zerotoprod\DataModel\DataModel;
+
+    public const int = 'int';
+
+    #[Describe(['pre' => [self::class, 'pre'], 'message' => 'Value too large.'])]
+    public int $int;
+
+    public static function pre($value, array $context, ?\ReflectionAttribute $Attribute, \ReflectionProperty $Property): void
+    {
+        if ($value > 10) {
+            throw new \RuntimeException($Attribute->getArguments()[0]['message']);
+        }
+    }
+}

--- a/tests/Unit/Examples/Pre/PreTest.php
+++ b/tests/Unit/Examples/Pre/PreTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Unit\Examples\Pre;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class
+PreTest extends TestCase
+{
+    #[Test] public function from(): void
+    {
+        $this->expectExceptionMessage('Value too large.');
+
+        BaseClass::from([
+            BaseClass::int => 100,
+        ]);
+    }
+
+    #[Test] public function fails_check(): void
+    {
+        $BaseClass = BaseClass::from([
+            BaseClass::int => 1,
+        ]);
+
+        self::assertEquals(1, $BaseClass->int);
+    }
+}


### PR DESCRIPTION
## Description
Add support for life-cycle hooks.

pre

```php
use Zerotoprod\DataModel\Describe;

class BaseClass
{
    use \Zerotoprod\DataModel\DataModel;

    #[Describe(['pre' => [self::class, 'pre'], 'message' => 'Value too large.'])]
    public int $int;

    public static function pre($value, array $context, ?\ReflectionAttribute $Attribute, \ReflectionProperty $Property): void
    {
        if ($value > 10) {
            throw new \RuntimeException($Attribute->getArguments()[0]['message']);
        }
    }
}

```

post

```php
use Zerotoprod\DataModel\Describe;

class BaseClass
{
    use \Zerotoprod\DataModel\DataModel;

    public const int = 'int';

    #[Describe(['post' => [self::class, 'post'], 'message' => 'Value too large.'])]
    public int $int;

    public static function post($value, array $context, ?\ReflectionAttribute $Attribute, \ReflectionProperty $Property): void
    {
        if ($value > 10) {
            throw new \RuntimeException($value.$Attribute->getArguments()[0]['message']);
        }
    }
}
```