### PR TITLE
feat/add-support-for-missing_as_null

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Transform data into hydrated objects by [describing](#property-level-cast) how t
 - [Transformations](#transformations): Describe how to resolve a value before instantiation.
 - [Required Properties](#required-properties): Throw an exception when a property is not set.
 - [Default Values](#default-values): Set a default property value.
+- [Nullable Missing Values](#nullable-missing-values): Resolve a missing value as null.
 
 ## Installation
 
@@ -134,7 +135,8 @@ The `Describe` attribute can accept these arguments.
     // 'cast' => 'strtoupper', 
     'required' => true,
     
-    'default' => 'value'
+    'default' => 'value',
+    'missing_as_null' => true,
 ])]
 ```
 
@@ -367,6 +369,33 @@ class User
 $user = User::from();
 
 echo $user->username // 'N/A'
+```
+
+## Nullable Missing Values
+
+Set missing values to null by setting `missing_as_null => true`. This can be placed at the class or property level.
+
+This prevents an Error when attempting to assess a property that has not been initialized.
+> Error: Typed property User::$age must not be accessed before initialization
+
+```php
+use Zerotoprod\DataModel\Describe;
+
+#[Describe(['missing_as_null' => true])]
+class User
+{
+    use \Zerotoprod\DataModel\DataModel;
+
+    public ?string $name;
+    
+    #[Describe(['missing_as_null' => true])]
+    public ?int $age;
+}
+
+$User = User::from();
+
+echo $User->name; // null
+echo $User->age;  // null
 ```
 
 ## Examples

--- a/src/DataModel.php
+++ b/src/DataModel.php
@@ -229,6 +229,10 @@ trait DataModel
                 if ($Describe->required ?? false) {
                     throw new PropertyRequiredException("Property: $property_name is required");
                 }
+                if (($ClassDescribe->missing_as_null ?? false) || ($Describe->missing_as_null ?? false)) {
+                    $self->{$property_name} = null;
+                    continue;
+                }
                 continue;
             }
 

--- a/src/Describe.php
+++ b/src/Describe.php
@@ -107,6 +107,7 @@ class Describe
     public mixed $default;
     public mixed $pre;
     public mixed $post;
+    public bool $missing_as_null;
 
     /**
      *  Pass an associative array to the constructor to describe the behavior of a property when it is resolved.
@@ -196,7 +197,7 @@ class Describe
      *  }
      *  ```
      *
-     * @param  string|array{'pre': string|string[], 'cast': string|string[], 'post': string|string[], 'required': bool, 'default': mixed, ...}|null|  $attributes
+     * @param  string|array{'pre': string|string[], 'cast': string|string[], 'post': string|string[], 'required': bool, 'default': mixed, 'missing_as_null': bool}|null|  $attributes
      *
      * @link https://github.com/zero-to-prod/data-model
      *

--- a/tests/Unit/Examples/MissingAsNull/MissingAsNullTest.php
+++ b/tests/Unit/Examples/MissingAsNull/MissingAsNullTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Tests\Unit\Examples\MissingAsNull;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class MissingAsNullTest extends TestCase
+{
+    #[Test] public function from(): void
+    {
+        $User = User::from([
+            'name' => 'John',
+        ]);
+
+        $this->assertEquals('John', $User->name);
+        $this->assertNull($User->age);
+    }
+}

--- a/tests/Unit/Examples/MissingAsNull/User.php
+++ b/tests/Unit/Examples/MissingAsNull/User.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tests\Unit\Examples\MissingAsNull;
+
+use Zerotoprod\DataModel\Describe;
+
+#[Describe(['missing_as_null' => true])]
+class User
+{
+    use \Zerotoprod\DataModel\DataModel;
+
+    public string $name;
+    public ?int $age;
+}

--- a/tests/Unit/Metadata/Cast/Helpers.php
+++ b/tests/Unit/Metadata/Cast/Helpers.php
@@ -2,14 +2,10 @@
 
 namespace Tests\Unit\Metadata\Cast;
 
-use DateMalformedStringException;
 use DateTimeImmutable;
 
 class Helpers
 {
-    /**
-     * @throws DateMalformedStringException
-     */
     public static function dateTimeImmutable($value): DateTimeImmutable
     {
         return new DateTimeImmutable($value);

--- a/tests/Unit/Metadata/MissingAsNull/MissingAsNullTest.php
+++ b/tests/Unit/Metadata/MissingAsNull/MissingAsNullTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests\Unit\Metadata\MissingAsNull;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class MissingAsNullTest extends TestCase
+{
+    #[Test] public function from(): void
+    {
+        $User = User::from();
+
+        $this->assertNull($User->name);
+        $this->assertNull($User->age);
+    }
+}

--- a/tests/Unit/Metadata/MissingAsNull/User.php
+++ b/tests/Unit/Metadata/MissingAsNull/User.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Tests\Unit\Metadata\MissingAsNull;
+
+use Zerotoprod\DataModel\Describe;
+
+#[Describe(['missing_as_null' => true])]
+class User
+{
+    use \Zerotoprod\DataModel\DataModel;
+
+    public ?string $name;
+
+    #[Describe(['missing_as_null' => true])]
+    public ?int $age;
+}


### PR DESCRIPTION
## Description

Add support for `missing_as_null`:

## Nullable Missing Values

Set missing values to null by setting `missing_as_null => true`. This can be placed at the class or property level.

This prevents an Error when attempting to assess a property that has not been initialized.
> Error: Typed property User::$age must not be accessed before initialization

```php
use Zerotoprod\DataModel\Describe;

#[Describe(['missing_as_null' => true])]
class User
{
    use \Zerotoprod\DataModel\DataModel;

    public ?string $name;
    
    #[Describe(['missing_as_null' => true])]
    public ?int $age;
}

$User = User::from();

echo $User->name; // null
echo $User->age;  // null
```