### PR TITLE
feat/add-re-mapping-support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Transform data into hydrated objects by [describing](#property-level-cast) how t
 - [Required Properties](#required-properties): Throw an exception when a property is not set.
 - [Default Values](#default-values): Set a default property value.
 - [Nullable Missing Values](#nullable-missing-values): Resolve a missing value as null.
+- [Remapping](#re-mapping): Re-map a key to a property of a different name.
 
 ## Installation
 
@@ -121,6 +122,8 @@ The `Describe` attribute can accept these arguments.
 
 ```php
 #[\Zerotoprod\DataModel\Describe([
+    // Re-map a key to a property of a different name
+    'from' => 'key', 
     // Runs before 'cast'
     'pre' => [MyClass::class, 'preHook']
     // Targets the static method: `MyClass::methodName()`
@@ -390,6 +393,28 @@ $User = User::from();
 
 echo $User->name; // null
 echo $User->age;  // null
+```
+
+## Re-Mapping
+
+You can map a key to a property of a different name like this:
+
+```php
+use Zerotoprod\DataModel\Describe;
+
+class User
+{
+    use \Zerotoprod\DataModel\DataModel;
+
+    #[Describe(['from' => 'firstName'])]
+    public string $first_name;
+}
+
+$User = User::from([
+    'firstName' => 'John',
+]);
+
+echo $User->first_name; // John
 ```
 
 ## Examples

--- a/src/Describe.php
+++ b/src/Describe.php
@@ -102,6 +102,7 @@ use Attribute;
 #[Attribute]
 class Describe
 {
+    public string $from;
     public string|array $cast;
     public bool $required;
     public mixed $default;
@@ -197,7 +198,7 @@ class Describe
      *  }
      *  ```
      *
-     * @param  string|array{'pre': string|string[], 'cast': string|string[], 'post': string|string[], 'required': bool, 'default': mixed, 'missing_as_null': bool}|null|  $attributes
+     * @param  string|array{'from': string,'pre': string|string[], 'cast': string|string[], 'post': string|string[], 'required': bool, 'default': mixed, 'missing_as_null': bool}|null|  $attributes
      *
      * @link https://github.com/zero-to-prod/data-model
      *

--- a/tests/Unit/Examples/From/ClassTest.php
+++ b/tests/Unit/Examples/From/ClassTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Unit\Examples\From;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class ClassTest extends TestCase
+{
+    #[Test] public function from(): void
+    {
+        $User = User::from([
+            'firstName' => '1',
+        ]);
+
+        $this->assertEquals('1', $User->first_name);
+    }
+}

--- a/tests/Unit/Examples/From/User.php
+++ b/tests/Unit/Examples/From/User.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Tests\Unit\Examples\From;
+
+use Zerotoprod\DataModel\Describe;
+
+class User
+{
+    use \Zerotoprod\DataModel\DataModel;
+
+    public const first_name = 'first_name';
+
+    #[Describe(['from' => 'firstName'])]
+    public string $first_name;
+}


### PR DESCRIPTION
## Description
Map a key to a property of a different name like this:

```php
use Zerotoprod\DataModel\Describe;

class User
{
    use \Zerotoprod\DataModel\DataModel;

    #[Describe(['from' => 'firstName'])]
    public string $first_name;
}

$User = User::from([
    'firstName' => 'John',
]);

echo $User->first_name; // John
```