### PR TITLE
docs/missing-as-null-limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,11 @@ $user = User::from();
 echo $user->username // 'N/A'
 ```
 
+### Limitations
+Note that using null as a default will not work: `#[Describe(['default' => null])]`.
+
+Use `#[Describe(['missing_as_null' => true])]` to set a null value.
+
 ## Nullable Missing Values
 
 Set missing values to null by setting `missing_as_null => true`. This can be placed at the class or property level.
@@ -394,6 +399,10 @@ $User = User::from();
 echo $User->name; // null
 echo $User->age;  // null
 ```
+### Limitations
+Note that using null as a default will not work: `#[Describe(['default' => null])]`.
+
+Use `#[Describe(['missing_as_null' => true])]` to set a null value.
 
 ## Re-Mapping
 

--- a/tests/Unit/Metadata/MissingAsNullProperty/MissingAsNullTest.php
+++ b/tests/Unit/Metadata/MissingAsNullProperty/MissingAsNullTest.php
@@ -12,6 +12,7 @@ class MissingAsNullTest extends TestCase
         $User = User::from();
 
         $this->assertNull($User->name);
+        $this->assertEmpty($User->last_name);
         $this->assertEquals(2, $User->age);
     }
 }

--- a/tests/Unit/Metadata/MissingAsNullProperty/User.php
+++ b/tests/Unit/Metadata/MissingAsNullProperty/User.php
@@ -12,6 +12,9 @@ class User
     #[Describe(['missing_as_null' => true])]
     public ?string $name;
 
+    #[Describe(['default' => ''])]
+    public string $last_name;
+
     #[Describe(['default' => 2])]
     public ?int $age;
 }


### PR DESCRIPTION
## Description
Add this

### Limitations
Note that using null as a default will not work: `#[Describe(['default' => null])]`.

Use `#[Describe(['missing_as_null' => true])]` to set a null value.