### PR TITLE
feat/add-support-for-ignoring-properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Transform data into hydrated objects by [describing](#property-level-cast) how t
 - [Default Values](#default-values): Set a default property value.
 - [Nullable Missing Values](#nullable-missing-values): Resolve a missing value as null.
 - [Remapping](#re-mapping): Re-map a key to a property of a different name.
+- [Ignoring Properties](#ignoring-properties): Ignore a resolving a property.
 
 ## Installation
 

--- a/src/DataModel.php
+++ b/src/DataModel.php
@@ -206,6 +206,11 @@ trait DataModel
             $Attribute = ($ReflectionProperty->getAttributes(Describe::class)[0] ?? null);
             /** @var Describe $Describe */
             $Describe = $Attribute?->newInstance();
+
+            if(isset($Describe->ignore) && $Describe->ignore){
+                continue;
+            }
+
             $context_key = $Describe->from ?? $ReflectionProperty->getName();
 
             /** Property-level Pre Hook */

--- a/src/Describe.php
+++ b/src/Describe.php
@@ -109,6 +109,7 @@ class Describe
     public mixed $pre;
     public mixed $post;
     public bool $missing_as_null;
+    public bool $ignore;
 
     /**
      *  Pass an associative array to the constructor to describe the behavior of a property when it is resolved.
@@ -198,7 +199,7 @@ class Describe
      *  }
      *  ```
      *
-     * @param  string|array{'from': string,'pre': string|string[], 'cast': string|string[], 'post': string|string[], 'required': bool, 'default': mixed, 'missing_as_null': bool}|null|  $attributes
+     * @param  string|array{'from': string,'pre': string|string[], 'cast': string|string[], 'post': string|string[], 'required': bool, 'default': mixed, 'missing_as_null': bool, 'ignore': bool}|null  $attributes
      *
      * @link https://github.com/zero-to-prod/data-model
      *

--- a/tests/Unit/Examples/Ignore/IgnoreTest.php
+++ b/tests/Unit/Examples/Ignore/IgnoreTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests\Unit\Examples\Ignore;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class IgnoreTest extends TestCase
+{
+    #[Test] public function from(): void
+    {
+        $user = User::from([
+            'name' => 'John Doe',
+            'age' => '30',
+        ]);
+
+        $this->assertEquals('John Doe', $user->name);
+        $this->assertFalse(isset($user->age));
+    }
+}

--- a/tests/Unit/Examples/Ignore/User.php
+++ b/tests/Unit/Examples/Ignore/User.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Tests\Unit\Examples\Ignore;
+
+use Tests\Unit\Examples\ExtendsTrait\DataModel;
+use Zerotoprod\DataModel\Describe;
+
+class User
+{
+    use DataModel;
+
+    public string $name;
+
+    #[Describe(['ignore' => true])]
+    public int $age;
+}


### PR DESCRIPTION
## Ignoring Properties

You can ignore a property like this:

```php
use Zerotoprod\DataModel\Describe;

class User
{
    use \Zerotoprod\DataModel\DataModel;

    public string $name;

    #[Describe(['ignore' => true])]
    public int $age;
}
```