### PR TITLE
feat/add-InvalidValue-exception-for-missing_as_null

### DIFF
--- a/src/Describe.php
+++ b/src/Describe.php
@@ -102,6 +102,7 @@ use Attribute;
 #[Attribute]
 class Describe
 {
+    public const missing_as_null = 'missing_as_null';
     public string $from;
     public string|array $cast;
     public bool $required;
@@ -212,6 +213,9 @@ class Describe
         if (is_countable($attributes)) {
             foreach ($attributes as $key => $value) {
                 if (property_exists($this, $key)) {
+                    if($key === self::missing_as_null && !is_bool($value)) {
+                        throw new InvalidValue(sprintf("Invalid value: `%s` should be a boolean.", self::missing_as_null));
+                    }
                     $this->$key = $value;
                 }
             }

--- a/src/InvalidValue.php
+++ b/src/InvalidValue.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Zerotoprod\DataModel;
+
+use RuntimeException;
+
+/**
+ * Thrown when a property is required.
+ *
+ * @link https://github.com/zero-to-prod/data-model
+ * @see  https://github.com/zero-to-prod/data-model-helper
+ * @see  https://github.com/zero-to-prod/data-model-factory
+ * @see  https://github.com/zero-to-prod/transformable
+ */
+class InvalidValue extends RuntimeException
+{
+
+}

--- a/tests/Unit/Describe/MissingAsNull/Boolean/BaseClass.php
+++ b/tests/Unit/Describe/MissingAsNull/Boolean/BaseClass.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests\Unit\Describe\MissingAsNull\Boolean;
+
+use Zerotoprod\DataModel\DataModel;
+use Zerotoprod\DataModel\Describe;
+
+class BaseClass
+{
+    use DataModel;
+
+    public const true = 'true';
+    public const false = 'false';
+
+    #[Describe(['missing_as_null' => true])]
+    public ?string $true;
+
+    #[Describe(['missing_as_null' => false])]
+    public string $false;
+}

--- a/tests/Unit/Describe/MissingAsNull/Boolean/ClassTest.php
+++ b/tests/Unit/Describe/MissingAsNull/Boolean/ClassTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests\Unit\Describe\MissingAsNull\Boolean;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class ClassTest extends TestCase
+{
+    #[Test] public function from(): void
+    {
+        $BaseClass = BaseClass::from();
+
+        self::assertNull($BaseClass->true);
+        self::assertFalse(isset($BaseClass->false));
+    }
+}

--- a/tests/Unit/Describe/MissingAsNull/Invalid/BaseClass.php
+++ b/tests/Unit/Describe/MissingAsNull/Invalid/BaseClass.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tests\Unit\Describe\MissingAsNull\Invalid;
+
+use Zerotoprod\DataModel\DataModel;
+use Zerotoprod\DataModel\Describe;
+
+class BaseClass
+{
+    use DataModel;
+
+    #[Describe(['missing_as_null' => []])]
+    public string $invalid;
+}

--- a/tests/Unit/Describe/MissingAsNull/Invalid/ClassTest.php
+++ b/tests/Unit/Describe/MissingAsNull/Invalid/ClassTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Tests\Unit\Describe\MissingAsNull\Invalid;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+use Zerotoprod\DataModel\InvalidValue;
+
+class ClassTest extends TestCase
+{
+    #[Test] public function from(): void
+    {
+        $this->expectException(InvalidValue::class);
+        BaseClass::from();
+    }
+}


### PR DESCRIPTION
## Description

Throw an exception when the value for `missing_is_null` is not a boolean.