### PR TITLE
feat/add-support-for-valueless-booleans-in-describe-properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ The `Describe` attribute can accept these arguments.
 
 ```php
 #[\Zerotoprod\DataModel\Describe([
-    'ignore' => true
+    'ignore' // ignores a property
     // Re-map a key to a property of a different name
     'from' => 'key', 
     // Runs before 'cast'
@@ -167,9 +167,9 @@ The `Describe` attribute can accept these arguments.
     // 'cast' => 'my_func', // alternately target a function
     // Runs after 'cast' passing the resolved value as `$value`
     'post' => [MyClass::class, 'postHook']
-    'required' => true,
     'default' => 'value',
-    'missing_as_null' => true,
+    'required', // Throws an exception if the element is missing
+    'missing_as_null', // sets the value to null if the element is missing
 ])]
 ```
 

--- a/src/DataModel.php
+++ b/src/DataModel.php
@@ -30,16 +30,19 @@ use UnitEnum;
  * Property-Level
  * ```
  * #[\Zerotoprod\DataModel\Describe([
+ *  'ignore' // ignores a property
+ *  // Re-map a key to a property of a different name
+ *  'from' => 'key',
  *  // Runs before 'cast'
  *  'pre' => [MyClass::class, 'preHook']
  *  // Targets the static method: `MyClass::methodName()`
  *  'cast' => [MyClass::class, 'castMethod'],
- *  // alternately target a function
- *  // 'cast' => 'my_func',
+ *  // 'cast' => 'my_func', // alternately target a function
  *  // Runs after 'cast' passing the resolved value as `$value`
  *  'post' => [MyClass::class, 'postHook']
- *  'required' => true,
- *  'default' => 'value'
+ *  'default' => 'value',
+ *  'required', // Throws an exception if the element is missing
+ *  'missing_as_null', // sets the value to null if the element is missing
  * ])]
  * public string $property;
  * ```
@@ -98,16 +101,19 @@ trait DataModel
      * Property-Level
      * ```
      * #[\Zerotoprod\DataModel\Describe([
+     *  'ignore' // ignores a property
+     *  // Re-map a key to a property of a different name
+     *  'from' => 'key',
      *  // Runs before 'cast'
      *  'pre' => [MyClass::class, 'preHook']
      *  // Targets the static method: `MyClass::methodName()`
      *  'cast' => [MyClass::class, 'castMethod'],
-     *  // alternately target a function
-     *  // 'cast' => 'my_func',
+     *  // 'cast' => 'my_func', // alternately target a function
      *  // Runs after 'cast' passing the resolved value as `$value`
      *  'post' => [MyClass::class, 'postHook']
-     *  'required' => true,
-     *  'default' => 'value'
+     *  'default' => 'value',
+     *  'required', // Throws an exception if the element is missing
+     *  'missing_as_null', // sets the value to null if the element is missing
      * ])]
      * public string $property;
      * ```

--- a/src/Describe.php
+++ b/src/Describe.php
@@ -103,13 +103,23 @@ use Attribute;
 class Describe
 {
     public const missing_as_null = 'missing_as_null';
+    public const required = 'required';
+    public const ignore = 'ignore';
+
     public string $from;
+
     public string|array $cast;
+
     public bool $required;
+
     public $default;
+
     public $pre;
+
     public $post;
+
     public bool $missing_as_null;
+
     public bool $ignore;
 
     /**
@@ -200,7 +210,8 @@ class Describe
      *  }
      *  ```
      *
-     * @param  string|array{'from': string,'pre': string|string[], 'cast': string|string[], 'post': string|string[], 'required': bool, 'default': mixed, 'missing_as_null': bool, 'ignore': bool}|null  $attributes
+     * @param  string|array{'from': string,'pre': string|string[], 'cast': string|string[], 'post': string|string[], 'required': bool, 'default': mixed, 'missing_as_null': bool,
+     *                                            'ignore': bool}|null  $attributes
      *
      * @link https://github.com/zero-to-prod/data-model
      *
@@ -213,10 +224,33 @@ class Describe
         if (is_countable($attributes)) {
             foreach ($attributes as $key => $value) {
                 if (property_exists($this, $key)) {
-                    if($key === self::missing_as_null && !is_bool($value)) {
+                    if ($key === self::missing_as_null && !is_bool($value)) {
                         throw new InvalidValue(sprintf("Invalid value: `%s` should be a boolean.", self::missing_as_null));
                     }
+
+                    if ($key === self::required && !is_bool($value)) {
+                        throw new InvalidValue(sprintf("Invalid value: `%s` should be a boolean.", self::required));
+                    }
+
+                    if ($key === self::ignore && !is_bool($value)) {
+                        throw new InvalidValue(sprintf("Invalid value: `%s` should be a boolean.", self::ignore));
+                    }
+
                     $this->$key = $value;
+                    continue;
+                }
+                if (property_exists($this, $value) && $key === 0) {
+                    if ($value === self::required) {
+                        $this->$value = true;
+                    }
+
+                    if ($value === self::missing_as_null) {
+                        $this->$value = true;
+                    }
+
+                    if ($value === self::ignore) {
+                        $this->$value = true;
+                    }
                 }
             }
         }

--- a/tests/Unit/Describe/MissingAsNull/Boolean/BaseClass.php
+++ b/tests/Unit/Describe/MissingAsNull/Boolean/BaseClass.php
@@ -12,7 +12,7 @@ class BaseClass
     public const true = 'true';
     public const false = 'false';
 
-    #[Describe(['missing_as_null' => true])]
+    #[Describe(['missing_as_null'])]
     public ?string $true;
 
     #[Describe(['missing_as_null' => false])]

--- a/tests/Unit/Describe/Required/BaseClass.php
+++ b/tests/Unit/Describe/Required/BaseClass.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests\Unit\Describe\Required;
+
+use Zerotoprod\DataModel\DataModel;
+use Zerotoprod\DataModel\Describe;
+
+class BaseClass
+{
+    use DataModel;
+
+    public const required = 'required';
+    public const required_no_value = 'required_no_value';
+
+    #[Describe(['required' => true])]
+    public string $required;
+
+    #[Describe(['required'])]
+    public string $required_no_value;
+}

--- a/tests/Unit/Describe/Required/IgnoresUnionsTest.php
+++ b/tests/Unit/Describe/Required/IgnoresUnionsTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Tests\Unit\Describe\Required;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+use Zerotoprod\DataModel\PropertyRequiredException;
+
+class IgnoresUnionsTest extends TestCase
+{
+
+    #[Test] public function required_with_value(): void
+    {
+        $this->expectException(PropertyRequiredException::class);
+        BaseClass::from([
+            BaseClass::required_no_value => '1',
+        ]);
+    }
+
+    #[Test] public function required_without_value(): void
+    {
+        $this->expectException(PropertyRequiredException::class);
+        BaseClass::from([
+            BaseClass::required => '1',
+        ]);
+    }
+}


### PR DESCRIPTION
## Description
Adds support for not having to pass a boolean for `missing_as_null`, `required`, and `ignore`. 