### PR TITLE
bugfix/remove-context-requirement-for-cast-hook

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,3 +11,4 @@
 /README.md                export-ignore
 /SECURITY.md              export-ignore
 /logo.png                 export-ignore
+/test.sh                  export-ignore

--- a/src/DataModel.php
+++ b/src/DataModel.php
@@ -242,7 +242,7 @@ trait DataModel
             }
 
             /** Property-level Cast */
-            if (isset($Describe->cast) && $context) {
+            if (isset($Describe->cast)) {
                 $self->{$property_name} = ($Describe->cast)($context[$context_key] ?? [], $context, $Attribute, $ReflectionProperty);
 
                 /** Property-level Post Hook */

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,16 @@
+# run-tests.sh
+set -e
+
+php_versions=("php83" "php82" "php81")
+
+for version in "${php_versions[@]}"; do
+  echo "Setting up environment..."
+  rm composer.lock
+  docker compose run --rm "$version"composer composer install
+  echo "Running tests on $version..."
+  if ! docker compose run --rm "$version" vendor/bin/phpunit; then
+    echo "Tests failed on $version."
+    exit 1
+  fi
+done
+echo "All tests passed!"


### PR DESCRIPTION
## Description
Remove `$context` from `cast` hook in `DataModel.php`.