### PR TITLE
Alias `missing_as_null` to `nullable`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ The `Describe` attribute can accept these arguments.
     'post' => [MyClass::class, 'postHook']
     'default' => 'value',
     'required', // Throws an exception if the element is missing
-    'missing_as_null', // sets the value to null if the element is missing
+    'nullable', // sets the value to null if the element is missing
 ])]
 ```
 
@@ -416,11 +416,11 @@ echo $User->username // 'N/A'
 
 Note that using `null` as a default will not work: `#[Describe(['default' => null])]`.
 
-Use `#[Describe(['missing_as_null' => true])]` to set a null value.
+Use `#[Describe(['nullable' => true])]` to set a null value.
 
 ## Nullable Missing Values
 
-Set missing values to null by setting `missing_as_null => true`. This can be placed at the class or property level.
+Set missing values to null by setting `['nullable' => true]`. This can be placed at the class or property level.
 
 This prevents an Error when attempting to assess a property that has not been initialized.
 > Error: Typed property User::$age must not be accessed before initialization
@@ -428,14 +428,14 @@ This prevents an Error when attempting to assess a property that has not been in
 ```php
 use Zerotoprod\DataModel\Describe;
 
-#[Describe(['missing_as_null' => true])]
+#[Describe(['nullable' => true])]
 class User
 {
     use \Zerotoprod\DataModel\DataModel;
 
     public ?string $name;
     
-    #[Describe(['missing_as_null' => true])]
+    #[Describe(['nullable' => true])]
     public ?int $age;
 }
 
@@ -449,7 +449,7 @@ echo $User->age;  // null
 
 Note that using `null` as a default will not work: `#[Describe(['default' => null])]`.
 
-Use `#[Describe(['missing_as_null' => true])]` to set a null value.
+Use `#[Describe(['nullable' => true])]` to set a null value.
 
 ## Re-Mapping
 

--- a/src/DataModel.php
+++ b/src/DataModel.php
@@ -42,7 +42,7 @@ use UnitEnum;
  *  'post' => [MyClass::class, 'postHook']
  *  'default' => 'value',
  *  'required', // Throws an exception if the element is missing
- *  'missing_as_null', // sets the value to null if the element is missing
+ *  'nullable', // sets the value to null if the element is missing
  * ])]
  * public string $property;
  * ```
@@ -113,7 +113,7 @@ trait DataModel
      *  'post' => [MyClass::class, 'postHook']
      *  'default' => 'value',
      *  'required', // Throws an exception if the element is missing
-     *  'missing_as_null', // sets the value to null if the element is missing
+     *  'nullable', // sets the value to null if the element is missing
      * ])]
      * public string $property;
      * ```
@@ -290,11 +290,11 @@ trait DataModel
                         )
                     );
                 }
-                if (isset($Describe->missing_as_null) && $Describe?->missing_as_null) {
+                if (isset($Describe->nullable) && $Describe?->nullable) {
                     $self->{$property_name} = null;
                     continue;
                 }
-                if (isset($ClassDescribe->missing_as_null) && $ClassDescribe?->missing_as_null) {
+                if (isset($ClassDescribe->nullable) && $ClassDescribe?->nullable) {
                     $self->{$property_name} = null;
                     continue;
                 }

--- a/src/Describe.php
+++ b/src/Describe.php
@@ -103,6 +103,7 @@ use Attribute;
 class Describe
 {
     public const missing_as_null = 'missing_as_null';
+    public const nullable = 'nullable';
     public const required = 'required';
     public const ignore = 'ignore';
 
@@ -118,7 +119,7 @@ class Describe
 
     public $post;
 
-    public bool $missing_as_null;
+    public bool $nullable;
 
     public bool $ignore;
 
@@ -210,7 +211,7 @@ class Describe
      *  }
      *  ```
      *
-     * @param  string|array{'from': string,'pre': string|string[], 'cast': string|string[], 'post': string|string[], 'required': bool, 'default': mixed, 'missing_as_null': bool,
+     * @param  string|array{'from': string,'pre': string|string[], 'cast': string|string[], 'post': string|string[], 'required': bool, 'default': mixed, 'nullable': bool,
      *                                            'ignore': bool}|null  $attributes
      *
      * @link https://github.com/zero-to-prod/data-model
@@ -224,8 +225,8 @@ class Describe
         if (is_countable($attributes)) {
             foreach ($attributes as $key => $value) {
                 if (property_exists($this, $key)) {
-                    if ($key === self::missing_as_null && !is_bool($value)) {
-                        throw new InvalidValue(sprintf("Invalid value: `%s` should be a boolean.", self::missing_as_null));
+                    if ($key === self::nullable && !is_bool($value)) {
+                        throw new InvalidValue(sprintf("Invalid value: `%s` should be a boolean.", self::nullable));
                     }
 
                     if ($key === self::required && !is_bool($value)) {
@@ -244,13 +245,27 @@ class Describe
                         $this->$value = true;
                     }
 
-                    if ($value === self::missing_as_null) {
+                    if ($value === self::nullable) {
                         $this->$value = true;
                     }
 
                     if ($value === self::ignore) {
                         $this->$value = true;
                     }
+                }
+                /**
+                 * Aliases
+                 */
+
+                if ($key === self::missing_as_null) {
+                    if (!is_bool($value)) {
+                        throw new InvalidValue(sprintf("Invalid value: `%s` should be a boolean.", self::missing_as_null));
+                    }
+                    $this->nullable = $value;
+                    continue;
+                }
+                if ($value === self::missing_as_null) {
+                    $this->nullable = true;
                 }
             }
         }

--- a/tests/Unit/Describe/Nullable/Boolean/BaseClass.php
+++ b/tests/Unit/Describe/Nullable/Boolean/BaseClass.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests\Unit\Describe\Nullable\Boolean;
+
+use Zerotoprod\DataModel\DataModel;
+use Zerotoprod\DataModel\Describe;
+
+class BaseClass
+{
+    use DataModel;
+
+    public const true = 'true';
+    public const false = 'false';
+
+    #[Describe(['nullable'])]
+    public ?string $true;
+
+    #[Describe(['nullable' => false])]
+    public string $false;
+}

--- a/tests/Unit/Describe/Nullable/Boolean/ClassTest.php
+++ b/tests/Unit/Describe/Nullable/Boolean/ClassTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests\Unit\Describe\Nullable\Boolean;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class ClassTest extends TestCase
+{
+    #[Test] public function from(): void
+    {
+        $BaseClass = BaseClass::from();
+
+        self::assertNull($BaseClass->true);
+        self::assertFalse(isset($BaseClass->false));
+    }
+}

--- a/tests/Unit/Describe/Nullable/Invalid/BaseClass.php
+++ b/tests/Unit/Describe/Nullable/Invalid/BaseClass.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tests\Unit\Describe\Nullable\Invalid;
+
+use Zerotoprod\DataModel\DataModel;
+use Zerotoprod\DataModel\Describe;
+
+class BaseClass
+{
+    use DataModel;
+
+    #[Describe(['nullable' => []])]
+    public string $invalid;
+}

--- a/tests/Unit/Describe/Nullable/Invalid/ClassTest.php
+++ b/tests/Unit/Describe/Nullable/Invalid/ClassTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Tests\Unit\Describe\Nullable\Invalid;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+use Zerotoprod\DataModel\InvalidValue;
+
+class ClassTest extends TestCase
+{
+    #[Test] public function from(): void
+    {
+        $this->expectException(InvalidValue::class);
+        BaseClass::from();
+    }
+}

--- a/tests/Unit/Examples/MissingAsNull/User.php
+++ b/tests/Unit/Examples/MissingAsNull/User.php
@@ -4,7 +4,7 @@ namespace Tests\Unit\Examples\MissingAsNull;
 
 use Zerotoprod\DataModel\Describe;
 
-#[Describe(['missing_as_null' => true])]
+#[Describe(['nullable' => true])]
 class User
 {
     use \Zerotoprod\DataModel\DataModel;

--- a/tests/Unit/Metadata/MissingAsNull/User.php
+++ b/tests/Unit/Metadata/MissingAsNull/User.php
@@ -5,13 +5,13 @@ namespace Tests\Unit\Metadata\MissingAsNull;
 use Zerotoprod\DataModel\DataModel;
 use Zerotoprod\DataModel\Describe;
 
-#[Describe(['missing_as_null' => true])]
+#[Describe(['nullable' => true])]
 class User
 {
     use DataModel;
 
     public ?string $name;
 
-    #[Describe(['missing_as_null' => true])]
+    #[Describe(['nullable' => true])]
     public ?int $age;
 }

--- a/tests/Unit/Metadata/MissingAsNullProperty/User.php
+++ b/tests/Unit/Metadata/MissingAsNullProperty/User.php
@@ -4,12 +4,12 @@ namespace Tests\Unit\Metadata\MissingAsNullProperty;
 
 use Zerotoprod\DataModel\Describe;
 
-//#[Describe(['missing_as_null' => true])]
+//#[Describe(['nullable' => true])]
 class User
 {
     use \Zerotoprod\DataModel\DataModel;
 
-    #[Describe(['missing_as_null' => true])]
+    #[Describe(['nullable' => true])]
     public ?string $name;
 
     #[Describe(['default' => ''])]


### PR DESCRIPTION
## Description
Alias `missing_as_null` to `nullable`.

This will use more natural language to communicate a nullable property.

This is a backwards-compatible change: `missing_as_null` will still work.
