### PR TITLE
feat/add-instance-support

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,6 +510,29 @@ $User = User::from([
 isset($User->age); // false
 ```
 
+## Using the Constructor
+
+You can use the constructor to instantiate a DataModel like this:
+```php
+class User
+{
+    use \Zerotoprod\DataModel\DataModel;
+
+    public string $name;
+
+    public function __construct(array $data = [])
+    {
+        self::from($data, $this);
+    }
+}
+
+$User = new User([
+    'name' => 'Jane Doe',
+]);
+
+echo $User->name; // 'Jane Doe'; 
+```
+
 ## Examples
 
 ### Array of DataModels

--- a/src/DataModel.php
+++ b/src/DataModel.php
@@ -6,6 +6,12 @@ use ReflectionAttribute;
 use ReflectionClass;
 use ReflectionException;
 use ReflectionUnionType;
+use Tests\Unit\DataModel\Bool\Child;
+use Tests\Unit\DataModel\Enum\IntEnum;
+use Tests\Unit\DataModel\Recursion\ShortNamespaceChild;
+use Tests\Unit\Describe\ClassDynamic\BaseClass;
+use Tests\Unit\Describe\DefaultPost\User;
+use Tests\Unit\Examples\AutomaticInstantiation\Address;
 use UnitEnum;
 
 /**
@@ -149,14 +155,15 @@ trait DataModel
      * @see  https://github.com/zero-to-prod/transformable
      *
      * @param  iterable|object|null|string  $context  Data to populate the instance.
+     * @param  mixed|null                   $instance
      */
-    public static function from(iterable|object|null|string $context = []): self
+    public static function from(iterable|object|null|string $context = [], mixed $instance = null): self
     {
         if ($context instanceof self) {
             return $context;
         }
 
-        $self = new self();
+        $self = $instance ?? new self();
 
         if (is_string($context)) {
             return $self;

--- a/tests/Unit/DataModel/Instance/InstanceTest.php
+++ b/tests/Unit/DataModel/Instance/InstanceTest.php
@@ -18,4 +18,15 @@ class InstanceTest extends TestCase
         $this->assertEquals(1, $BaseClass->id);
         $this->assertEquals('name', $BaseClass->name);
     }
+
+    #[Test] public function creates_instance_from_constructor(): void
+    {
+        $BaseClass = new BaseClass([
+            BaseClass::id => 1,
+            BaseClass::name => 'name'
+        ]);
+
+        $this->assertEquals(1, $BaseClass->id);
+        $this->assertEquals('name', $BaseClass->name);
+    }
 }

--- a/tests/Unit/Examples/Instance/InstanceTest.php
+++ b/tests/Unit/Examples/Instance/InstanceTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Tests\Unit\Examples\Instance;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class InstanceTest extends TestCase
+{
+
+    #[Test] public function creates_instance_from_array(): void
+    {
+        $BaseClass = new User([
+           'name' => 'name'
+        ]);
+
+        $this->assertEquals('name', $BaseClass->name);
+    }
+}

--- a/tests/Unit/Examples/Instance/User.php
+++ b/tests/Unit/Examples/Instance/User.php
@@ -1,16 +1,13 @@
 <?php
 
-namespace Tests\Unit\DataModel\Instance;
+namespace Tests\Unit\Examples\Instance;
 
 use Zerotoprod\DataModel\DataModel;
 
-class BaseClass
+class User
 {
     use DataModel;
 
-    public const id = 'id';
-    public const name = 'name';
-    public int $id;
     public string $name;
 
     public function __construct(array $data = [])


### PR DESCRIPTION
## Description


## Using the Constructor

You can use the constructor to instantiate a DataModel like this:
```php
class User
{
    use \Zerotoprod\DataModel\DataModel;

    public string $name;

    public function __construct(array $data = [])
    {
        self::from($data, $this);
    }
}

$User = new User([
    'name' => 'Jane Doe',
]);

echo $User->name; // 'Jane Doe'; 
```