### PR TITLE
feat/via

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@
 - [Re-Mapping](#re-mapping)
 - [Ignoring Properties](#ignoring-properties)
 - [Using the Constructor](#using-the-constructor)
+- [Targeting a function to Instantiate a Class](#targeting-a-function-to-instantiate-a-class)
 - [Extending DataModels](#extending-datamodels)
 - [Examples](#examples)
     - [Hydrating From a Laravel Model](#hydrating-from-a-laravel-model) 
@@ -260,6 +261,8 @@ The `Describe` attribute can accept these arguments.
     'default' => 'value',
     'required', // Throws an exception if the element is missing
     'nullable', // sets the value to null if the element is missing
+     // The callable to instantiate the class
+     'via' => [MyClass::class, 'staticMethod'] // or 'my_func',
 ])]
 ```
 
@@ -576,7 +579,7 @@ class User
 
     public string $name;
 
-    #[Describe(['ignore' => true])]
+    #[Describe(['ignore'])]
     public int $age;
 }
 ```
@@ -622,6 +625,45 @@ $User = new User([
 ]);
 
 echo $User->name; // 'Jane Doe'; 
+```
+
+## Targeting a function to Instantiate a Class
+
+To resolve naming conflicts or to control how a class is instantiated, use the 'via' key.
+
+```php
+use Zerotoprod\DataModel\Describe;
+
+class BaseClass
+{
+    use DataModel;
+
+    #[Describe(['via' => 'via'])]
+    public ChildClass $ChildClass;
+
+    #[Describe(['via' => [ChildClass::class, 'via']])]
+    public ChildClass $ChildClass2;
+}
+
+class ChildClass
+{
+    public function __construct(public int $int)
+    {
+    }
+
+    public static function via(array $context): self
+    {
+        return new self($context[self::int]);
+    }
+}
+
+$BaseClass = BaseClass::from([
+    'ChildClass' => ['int' => 1],
+    'ChildClass2' => ['int' => 1],
+]);
+
+$BaseClass->ChildClass->int;  // 1
+$BaseClass->ChildClass2->int; // 1
 ```
 
 ## Extending DataModels

--- a/src/Describe.php
+++ b/src/Describe.php
@@ -123,6 +123,8 @@ class Describe
 
     public bool $ignore;
 
+    public string|array $via;
+
     /**
      *  Pass an associative array to the constructor to describe the behavior of a property when it is resolved.
      *
@@ -212,7 +214,7 @@ class Describe
      *  ```
      *
      * @param  string|array{'from': string,'pre': string|string[], 'cast': string|string[], 'post': string|string[], 'required': bool, 'default': mixed, 'nullable': bool,
-     *                                            'ignore': bool}|null  $attributes
+     *                                            'ignore': bool, 'via': string}|null  $attributes
      *
      * @link https://github.com/zero-to-prod/data-model
      *

--- a/tests/Unit/Describe/Via/BaseClass.php
+++ b/tests/Unit/Describe/Via/BaseClass.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Unit\Describe\Via;
+
+use ReflectionAttribute;
+use ReflectionProperty;
+use RuntimeException;
+use Zerotoprod\DataModel\DataModel;
+use Zerotoprod\DataModel\Describe;
+
+class BaseClass
+{
+    use DataModel;
+
+    public const ChildClass = 'ChildClass';
+    public const ChildClass2 = 'ChildClass2';
+
+    #[Describe(['via' => 'via'])]
+    public ChildClass $ChildClass;
+
+    #[Describe(['via' => [ChildClass::class, 'via']])]
+    public ChildClass $ChildClass2;
+}

--- a/tests/Unit/Describe/Via/ChildClass.php
+++ b/tests/Unit/Describe/Via/ChildClass.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests\Unit\Describe\Via;
+
+class ChildClass
+{
+    public const int = 'int';
+
+    public function __construct(public int $int)
+    {
+    }
+
+    public static function via(array $context): self
+    {
+        return new self($context[self::int]);
+    }
+}

--- a/tests/Unit/Describe/Via/ViaTest.php
+++ b/tests/Unit/Describe/Via/ViaTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\Unit\Describe\Via;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class ViaTest extends TestCase
+{
+    #[Test] public function from(): void
+    {
+        $BaseClass = BaseClass::from([
+            BaseClass::ChildClass => [
+                ChildClass::int => 1
+            ],
+            BaseClass::ChildClass2 => [
+                ChildClass::int => 1
+            ],
+        ]);
+
+        self::assertEquals(1, $BaseClass->ChildClass->int);
+        self::assertEquals(1, $BaseClass->ChildClass2->int);
+    }
+}

--- a/tests/Unit/Examples/Ignore/IgnoreTest.php
+++ b/tests/Unit/Examples/Ignore/IgnoreTest.php
@@ -12,9 +12,11 @@ class IgnoreTest extends TestCase
         $user = User::from([
             'name' => 'John Doe',
             'age' => '30',
+            'height' => '30',
         ]);
 
         $this->assertEquals('John Doe', $user->name);
         $this->assertFalse(isset($user->age));
+        $this->assertFalse(isset($user->height));
     }
 }

--- a/tests/Unit/Examples/Ignore/User.php
+++ b/tests/Unit/Examples/Ignore/User.php
@@ -13,4 +13,7 @@ class User
 
     #[Describe(['ignore' => true])]
     public int $age;
+
+    #[Describe(['ignore'])]
+    public int $height;
 }


### PR DESCRIPTION
## Description
To resolve naming conflicts or to control how a class is instantiated, use the 'via' key.

```php
use Zerotoprod\DataModel\Describe;

class BaseClass
{
    use DataModel;

    #[Describe(['via' => 'via'])]
    public ChildClass $ChildClass;

    #[Describe(['via' => [ChildClass::class, 'via']])]
    public ChildClass $ChildClass2;
}

class ChildClass
{
    public function __construct(public int $int)
    {
    }

    public static function via(array $context): self
    {
        return new self($context[self::int]);
    }
}

$BaseClass = BaseClass::from([
    'ChildClass' => ['int' => 1],
    'ChildClass2' => ['int' => 1],
]);

$BaseClass->ChildClass->int;  // 1
$BaseClass->ChildClass2->int; // 1
```