### PR TITLE
Update Describe params to be optional

### DIFF
--- a/src/Describe.php
+++ b/src/Describe.php
@@ -219,8 +219,8 @@ class Describe
      *  }
      *  ```
      *
-     * @param  string|array{'from': string,'pre': string|string[], 'cast': string|string[], 'post': string|string[], 'required': bool, 'default': mixed, 'nullable': bool,
-     *                                            'ignore': bool, 'via': string}|null  $attributes
+     * @param  string|array{'from'?: string, 'pre'?: string|string[], 'cast'?: string|string[], 'post'?: string|string[], 'required'?: bool, 'default'?: mixed, 'nullable'?: bool,
+     *                                            'ignore'?: bool, 'via'?: string}|null  $attributes
      *
      * @link https://github.com/zero-to-prod/data-model
      *


### PR DESCRIPTION
when using the array format to describe the config, allow all of the array keys to be optional so that you don't have to define them all just to pass static analysis.

## Description

without this, then 
```
    #[Describe(['from' => 'owner_id'])]
    public string $ownerId;
```
would throw 

```
Error: Parameter #1 $attributes of attribute class Zerotoprod\DataModel\Describe constructor expects array{from: string, pre: array<string>|string, cast: array<string>|string, post: array<string>|string, required: bool, default: mixed, nullable: bool, ignore: bool, ...}|string|null, array{from: 'organisation_id'} given.
```