### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/backwards_compatibility.yml
+++ b/.github/workflows/backwards_compatibility.yml
@@ -1,5 +1,8 @@
 name: backwards_compatibility
 
+permissions:
+  contents: read
+
 on:
   push:
 


### PR DESCRIPTION
Potential fix for [https://github.com/zero-to-prod/data-model/security/code-scanning/3](https://github.com/zero-to-prod/data-model/security/code-scanning/3)

To fix the issue, add a `permissions` block at the root of the workflow file. Since the workflow only needs to read the repository contents (e.g., for checking out the code), set `contents: read` as the permission. This ensures that the workflow operates with the least privilege necessary to perform its tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
