### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/zero-to-prod/data-model/security/code-scanning/2](https://github.com/zero-to-prod/data-model/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will explicitly set the permissions to `contents: read`, which is sufficient for the workflow's tasks, such as checking out the code and running tests. This change ensures that the workflow does not inadvertently gain unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
