### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/composer_require_checker.yml
+++ b/.github/workflows/composer_require_checker.yml
@@ -1,5 +1,8 @@
 name: composer_require_checker
 
+permissions:
+  contents: read
+
 on:
   push:
 


### PR DESCRIPTION
Potential fix for [https://github.com/zero-to-prod/data-model/security/code-scanning/1](https://github.com/zero-to-prod/data-model/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function correctly. Since the workflow only needs to read the repository contents (e.g., to check out the code and install dependencies), we will set `contents: read`. This ensures that the workflow does not have unnecessary write permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
