### PR TITLE
Add support for single-argument cast functions

### DIFF
--- a/src/DataModel.php
+++ b/src/DataModel.php
@@ -5,6 +5,8 @@ namespace Zerotoprod\DataModel;
 use ReflectionAttribute;
 use ReflectionClass;
 use ReflectionException;
+use ReflectionFunction;
+use ReflectionMethod;
 use ReflectionUnionType;
 use UnitEnum;
 
@@ -247,7 +249,12 @@ trait DataModel
 
             /** Property-level Cast */
             if (isset($Describe->cast)) {
-                $self->{$property_name} = ($Describe->cast)($context[$context_key] ?? null, $context, $Attribute, $ReflectionProperty);
+                $param_count = (new (is_array($Describe->cast) ? ReflectionMethod::class : ReflectionFunction::class)(...(array)$Describe->cast))
+                    ->getNumberOfParameters();
+
+                $self->{$property_name} = $param_count === 1
+                    ? ($Describe->cast)($context[$context_key] ?? null)
+                    : ($Describe->cast)($context[$context_key] ?? null, $context, $Attribute, $ReflectionProperty);
 
                 /** Property-level Post Hook */
                 if (isset($Describe->post)) {

--- a/src/Describe.php
+++ b/src/Describe.php
@@ -102,33 +102,90 @@ use Attribute;
 #[Attribute]
 class Describe
 {
+    /**
+     * @link https://github.com/zero-to-prod/data-model
+     */
     public const missing_as_null = 'missing_as_null';
-    /** @see $from */
+    /**
+     * @see $from
+     * @link https://github.com/zero-to-prod/data-model
+     */
     public const from = 'from';
+    /**
+     * @link https://github.com/zero-to-prod/data-model
+     */
     public string $from;
-    /** @see $cast */
+    /**
+     * @see $cast
+     * @link https://github.com/zero-to-prod/data-model
+     */
     public const cast = 'cast';
+    /**
+     * @link https://github.com/zero-to-prod/data-model
+     */
     public string|array $cast;
-    /** @see $required */
+    /**
+     * @see $required
+     * @link https://github.com/zero-to-prod/data-model
+     */
     public const required = 'required';
+    /**
+     * @link https://github.com/zero-to-prod/data-model
+     */
     public bool $required;
-    /** @see $default */
+    /**
+     * @see $default
+     * @link https://github.com/zero-to-prod/data-model
+     */
     public const default = 'default';
+    /**
+     * @link https://github.com/zero-to-prod/data-model
+     */
     public $default;
-    /** @see $pre */
+    /**
+     * @see $pre
+     * @link https://github.com/zero-to-prod/data-model
+     */
     public const pre = 'pre';
+    /**
+     * @link https://github.com/zero-to-prod/data-model
+     */
     public $pre;
-    /** @see $post */
+    /**
+     * @see $post
+     * @link https://github.com/zero-to-prod/data-model
+     */
     public const post = 'post';
+    /**
+     * @link https://github.com/zero-to-prod/data-model
+     */
     public $post;
-    /** @see $nullable */
+    /**
+     * @see $nullable
+     * @link https://github.com/zero-to-prod/data-model
+     */
     public const nullable = 'nullable';
+    /**
+     * @link https://github.com/zero-to-prod/data-model
+     */
     public bool $nullable;
-    /** @see $ignore */
+    /**
+     * @see $ignore
+     * @link https://github.com/zero-to-prod/data-model
+     */
     public const ignore = 'ignore';
+    /**
+     * @link https://github.com/zero-to-prod/data-model
+     */
     public bool $ignore;
-    /** @see $via */
+    /**
+     * @see $via
+     * @link https://github.com/zero-to-prod/data-model
+     */
     public const via = 'via';
+    /**
+     * @link https://github.com/zero-to-prod/data-model
+     */
     public string|array $via;
 
     /**

--- a/tests/Unit/Describe/CastSingleArg/CastSingleArgModel.php
+++ b/tests/Unit/Describe/CastSingleArg/CastSingleArgModel.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tests\Unit\Describe\CastSingleArg;
+
+use Zerotoprod\DataModel\DataModel;
+use Zerotoprod\DataModel\Describe;
+
+class CastSingleArgModel
+{
+    use DataModel;
+
+    #[Describe(['cast' => 'strtolower'])]
+    public string $name;
+}

--- a/tests/Unit/Describe/CastSingleArg/CastSingleArgTest.php
+++ b/tests/Unit/Describe/CastSingleArg/CastSingleArgTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Tests\Unit\Describe\CastSingleArg;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class CastSingleArgTest extends TestCase
+{
+    #[Test]
+    public function cast_with_single_argument_function(): void
+    {
+        $model = CastSingleArgModel::from([
+            'name' => 'HELLO WORLD',
+        ]);
+
+        $this->assertEquals('hello world', $model->name);
+    }
+}


### PR DESCRIPTION
## Description

- Fix ArgumentCountError when using built-in PHP functions (like strtolower) as cast callables
- Add reflection-based parameter count detection to pass appropriate number of arguments to cast functions

Before: Cast functions always received 4 arguments, causing built-in functions to fail:
ArgumentCountError: strtolower() expects exactly 1 argument, 4 given

After: Functions with 1 parameter receive only the value; others receive all 4 arguments:
```php
#[Describe(['cast' => 'strtolower'])]
public string $name; // Now works
```