### PR TITLE
Support subclassing Describe and treat string context as empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ All callables (`cast`, `pre`, `post`, `default`, `assign`) auto-detect parameter
 - [Using the Constructor](#using-the-constructor)
 - [Targeting a function to Instantiate a Class](#targeting-a-function-to-instantiate-a-class)
 - [Extending DataModels](#extending-datamodels)
+- [Subclassing Describe](#subclassing-describe)
+- [String Context](#string-context)
 - [Examples](#examples)
     - [Hydrating From a Laravel Model](#hydrating-from-a-laravel-model)
     - [Array of DataModels](#array-of-datamodels)
@@ -197,7 +199,7 @@ class User
 
 ### Hydrating from Data
 
-Pass an associative array or object to `from()`:
+Pass an associative array, object, or nothing to `from()`. Strings and `null` are treated as empty context:
 
 ```php
 $User = User::from([
@@ -242,7 +244,7 @@ echo $User->address->city; // 'Hometown'
 
 ## Transformations
 
-The `Describe` attribute declaratively configures how property values are resolved.
+The `Describe` attribute (or any subclass of it) declaratively configures how property values are resolved.
 
 ### Property-Level Cast
 
@@ -715,6 +717,61 @@ trait DataModel
         return collect($this)->toArray();
     }
 }
+```
+
+## Subclassing Describe
+
+You can extend `Describe` to create a project-specific attribute. Subclasses are automatically
+recognized by `from()` — all keys (`default`, `nullable`, `cast`, etc.) work identically.
+
+```php
+use Attribute;
+use Zerotoprod\DataModel\Describe;
+
+#[Attribute]
+class MyDescribe extends Describe {}
+```
+
+Then use it on your models:
+
+```php
+readonly class Config
+{
+    use \Zerotoprod\DataModel\DataModel;
+
+    #[MyDescribe(['default' => 'fallback'])]
+    public string $name;
+
+    #[MyDescribe(['nullable' => true])]
+    public ?string $label;
+}
+
+$Config = Config::from();
+
+echo $Config->name;  // 'fallback'
+echo $Config->label; // null
+```
+
+## String Context
+
+When `from()` receives a string, it is treated as empty context. Attribute defaults (`default`, `assign`, `nullable`) still apply:
+
+```php
+class User
+{
+    use \Zerotoprod\DataModel\DataModel;
+
+    #[Describe(['default' => 'guest'])]
+    public string $role;
+
+    #[Describe(['nullable' => true])]
+    public ?string $name;
+}
+
+$User = User::from('any_string');
+
+echo $User->role; // 'guest'
+echo $User->name; // null
 ```
 
 ## Examples

--- a/src/DataModel.php
+++ b/src/DataModel.php
@@ -23,7 +23,8 @@ use function is_string;
  * Properties are resolved by matching array keys to property names. Type-hinted classes
  * are recursively instantiated via their own `from()` method.
  *
- * Configure per-property behavior with the `#[Describe]` attribute. See {@see Describe} for all available keys.
+ * Configure per-property behavior with the `#[Describe]` attribute (or any subclass of it).
+ * See {@see Describe} for all available keys.
  *
  * Resolution order (first match wins):
  *  1. `assign`  — unconditional value (context ignored)
@@ -43,7 +44,7 @@ trait DataModel
      * Hydrate an instance from an array, object, or null.
      *
      * Returns `$context` unchanged when it is already an instance of the class.
-     * Returns a blank instance when `$context` is a string.
+     * Treats string `$context` as empty — attribute defaults (`default`, `assign`, `nullable`) still apply.
      *
      * ```
      * $user = User::from(['name' => 'Jane', 'age' => 30]);
@@ -80,7 +81,7 @@ trait DataModel
      * #[Describe(['cast' => ['string' => 'strtoupper', DateTimeImmutable::class => [self::class, 'toDate']]])]
      * ```
      *
-     * @param  array|object|null|string  $context   Data to populate the instance.
+     * @param  array|object|null|string  $context   Data to populate the instance. Strings are treated as empty context.
      * @param  mixed|null                $instance  Optional pre-created instance to populate.
      *
      * @return self
@@ -99,21 +100,22 @@ trait DataModel
 
         $self = $instance ?? new self();
 
+        /** Treat string context as empty so attribute defaults (default, assign, nullable) still apply. */
         if (is_string($context)) {
-            return $self;
+            $context = [];
         }
 
         $ReflectionClass = new ReflectionClass($self);
-        /** Get Describe Attribute on class. */
+        /** Get Describe Attribute on class (IS_INSTANCEOF matches subclasses of Describe). */
         /** @var ReflectionAttribute|bool $ClassAttribute */
-        $ClassAttribute = current($ReflectionClass->getAttributes(Describe::class));
+        $ClassAttribute = current($ReflectionClass->getAttributes(Describe::class, ReflectionAttribute::IS_INSTANCEOF));
         /** @var Describe|null $ClassDescribe */
         $ClassDescribe = $ClassAttribute ? $ClassAttribute->newInstance() : null;
         $ClassDescribeArguments = $ClassAttribute ? $ClassAttribute->getArguments() : null;
 
         $methods = [];
         foreach ($ReflectionClass->getMethods() as $ReflectionMethod) {
-            $ReflectionAttributes = $ReflectionMethod->getAttributes(Describe::class);
+            $ReflectionAttributes = $ReflectionMethod->getAttributes(Describe::class, ReflectionAttribute::IS_INSTANCEOF);
             foreach ($ReflectionAttributes as $ReflectionAttribute) {
                 $property = $ReflectionAttribute->getArguments()[0];
                 try {
@@ -149,7 +151,7 @@ trait DataModel
         $ReflectionProperties = $ReflectionClass->getProperties();
         foreach ($ReflectionProperties as $ReflectionProperty) {
             $propertyAttributes[$ReflectionProperty->getName()] =
-                $ReflectionProperty->getAttributes(Describe::class)[0] ?? null;
+                $ReflectionProperty->getAttributes(Describe::class, ReflectionAttribute::IS_INSTANCEOF)[0] ?? null;
         }
 
         $context = is_object($context) ? (array)$context : $context ?? [];

--- a/src/Describe.php
+++ b/src/Describe.php
@@ -47,6 +47,13 @@ use function is_string;
  *  - 1 param:  `function($value): mixed`
  *  - 4 params: `function($value, array $context, ?ReflectionAttribute $Attr, ReflectionProperty $Prop): mixed`
  *
+ * **Subclassing** — You can extend this class to create a project-specific attribute.
+ * Subclasses are automatically recognized by {@see DataModel::from()} via `ReflectionAttribute::IS_INSTANCEOF`:
+ * ```
+ * #[Attribute]
+ * class MyDescribe extends Describe {}
+ * ```
+ *
  * @link https://github.com/zero-to-prod/data-model
  */
 #[Attribute]

--- a/tests/Unit/DataModel/FromString/BaseClass.php
+++ b/tests/Unit/DataModel/FromString/BaseClass.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tests\Unit\DataModel\FromString;
+
+use Zerotoprod\DataModel\DataModel;
+use Zerotoprod\DataModel\Describe;
+
+readonly class BaseClass
+{
+    use DataModel;
+
+    #[Describe(['nullable' => true])]
+    public ?string $nullable_prop;
+
+    #[Describe(['default' => 'fallback'])]
+    public string $default_prop;
+
+    #[Describe(['default' => [self::class, 'defaultCallable']])]
+    public string $default_callable_prop;
+
+    #[Describe(['assign' => 'fixed'])]
+    public string $assign_prop;
+
+    #[Describe(['assign' => [self::class, 'assignCallable']])]
+    public string $assign_callable_prop;
+
+    #[Describe(['ignore' => true])]
+    public string $ignored_prop;
+
+    public static int $pre_called = 0;
+    public static int $post_called = 0;
+
+    #[Describe(['pre' => [self::class, 'preHook'], 'nullable' => true])]
+    public ?string $pre_prop;
+
+    #[Describe(['post' => [self::class, 'postHook'], 'nullable' => true])]
+    public ?string $post_prop;
+
+    public static function defaultCallable(): string
+    {
+        return 'callable_default';
+    }
+
+    public static function assignCallable(): string
+    {
+        return 'callable_assign';
+    }
+
+    public static function preHook(mixed $value, array $context, ?\ReflectionAttribute $Attribute, \ReflectionProperty $Property): void
+    {
+        self::$pre_called++;
+    }
+
+    public static function postHook(mixed $value, array $context, ?\ReflectionAttribute $Attribute, \ReflectionProperty $Property): void
+    {
+        self::$post_called++;
+    }
+}

--- a/tests/Unit/DataModel/FromString/BaseClass.php
+++ b/tests/Unit/DataModel/FromString/BaseClass.php
@@ -5,7 +5,7 @@ namespace Tests\Unit\DataModel\FromString;
 use Zerotoprod\DataModel\DataModel;
 use Zerotoprod\DataModel\Describe;
 
-readonly class BaseClass
+class BaseClass
 {
     use DataModel;
 
@@ -27,15 +27,6 @@ readonly class BaseClass
     #[Describe(['ignore' => true])]
     public string $ignored_prop;
 
-    public static int $pre_called = 0;
-    public static int $post_called = 0;
-
-    #[Describe(['pre' => [self::class, 'preHook'], 'nullable' => true])]
-    public ?string $pre_prop;
-
-    #[Describe(['post' => [self::class, 'postHook'], 'nullable' => true])]
-    public ?string $post_prop;
-
     public static function defaultCallable(): string
     {
         return 'callable_default';
@@ -44,15 +35,5 @@ readonly class BaseClass
     public static function assignCallable(): string
     {
         return 'callable_assign';
-    }
-
-    public static function preHook(mixed $value, array $context, ?\ReflectionAttribute $Attribute, \ReflectionProperty $Property): void
-    {
-        self::$pre_called++;
-    }
-
-    public static function postHook(mixed $value, array $context, ?\ReflectionAttribute $Attribute, \ReflectionProperty $Property): void
-    {
-        self::$post_called++;
     }
 }

--- a/tests/Unit/DataModel/FromString/ClassNullable.php
+++ b/tests/Unit/DataModel/FromString/ClassNullable.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Tests\Unit\DataModel\FromString;
+
+use Zerotoprod\DataModel\DataModel;
+use Zerotoprod\DataModel\Describe;
+
+#[Describe(['nullable' => true])]
+readonly class ClassNullable
+{
+    use DataModel;
+
+    public ?string $name;
+    public ?int $age;
+}

--- a/tests/Unit/DataModel/FromString/ClassNullable.php
+++ b/tests/Unit/DataModel/FromString/ClassNullable.php
@@ -6,7 +6,7 @@ use Zerotoprod\DataModel\DataModel;
 use Zerotoprod\DataModel\Describe;
 
 #[Describe(['nullable' => true])]
-readonly class ClassNullable
+class ClassNullable
 {
     use DataModel;
 

--- a/tests/Unit/DataModel/FromString/FromStringTest.php
+++ b/tests/Unit/DataModel/FromString/FromStringTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit\DataModel\FromString;
 
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
+use Zerotoprod\DataModel\PropertyRequiredException;
 
 class FromStringTest extends TestCase
 {
@@ -21,11 +22,65 @@ class FromStringTest extends TestCase
         $this->assertEquals('fallback', $BaseClass->default_prop);
     }
 
+    #[Test] public function default_callable_applied(): void
+    {
+        $BaseClass = BaseClass::from('context');
+
+        $this->assertEquals('callable_default', $BaseClass->default_callable_prop);
+    }
+
     #[Test] public function assign_applied(): void
     {
         $BaseClass = BaseClass::from('context');
 
         $this->assertEquals('fixed', $BaseClass->assign_prop);
+    }
+
+    #[Test] public function assign_callable_applied(): void
+    {
+        $BaseClass = BaseClass::from('context');
+
+        $this->assertEquals('callable_assign', $BaseClass->assign_callable_prop);
+    }
+
+    #[Test] public function ignore_skips_property(): void
+    {
+        $BaseClass = BaseClass::from('context');
+
+        $this->assertFalse(isset($BaseClass->ignored_prop));
+    }
+
+    #[Test] public function required_throws(): void
+    {
+        $this->expectException(PropertyRequiredException::class);
+
+        RequiredClass::from('context');
+    }
+
+    #[Test] public function pre_hook_fires(): void
+    {
+        HookClass::$pre_called = 0;
+
+        HookClass::from('context');
+
+        $this->assertEquals(1, HookClass::$pre_called);
+    }
+
+    #[Test] public function post_hook_fires(): void
+    {
+        HookClass::$post_called = 0;
+
+        HookClass::from('context');
+
+        $this->assertEquals(1, HookClass::$post_called);
+    }
+
+    #[Test] public function class_level_nullable(): void
+    {
+        $ClassNullable = ClassNullable::from('context');
+
+        $this->assertNull($ClassNullable->name);
+        $this->assertNull($ClassNullable->age);
     }
 
     #[Test] public function empty_string_nullable(): void

--- a/tests/Unit/DataModel/FromString/FromStringTest.php
+++ b/tests/Unit/DataModel/FromString/FromStringTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Tests\Unit\DataModel\FromString;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class FromStringTest extends TestCase
+{
+    #[Test] public function nullable_set_to_null(): void
+    {
+        $BaseClass = BaseClass::from('context');
+
+        $this->assertNull($BaseClass->nullable_prop);
+    }
+
+    #[Test] public function default_applied(): void
+    {
+        $BaseClass = BaseClass::from('context');
+
+        $this->assertEquals('fallback', $BaseClass->default_prop);
+    }
+
+    #[Test] public function assign_applied(): void
+    {
+        $BaseClass = BaseClass::from('context');
+
+        $this->assertEquals('fixed', $BaseClass->assign_prop);
+    }
+
+    #[Test] public function empty_string_nullable(): void
+    {
+        $BaseClass = BaseClass::from('');
+
+        $this->assertNull($BaseClass->nullable_prop);
+    }
+
+    #[Test] public function empty_string_default(): void
+    {
+        $BaseClass = BaseClass::from('');
+
+        $this->assertEquals('fallback', $BaseClass->default_prop);
+    }
+
+    #[Test] public function empty_string_assign(): void
+    {
+        $BaseClass = BaseClass::from('');
+
+        $this->assertEquals('fixed', $BaseClass->assign_prop);
+    }
+}

--- a/tests/Unit/DataModel/FromString/HookClass.php
+++ b/tests/Unit/DataModel/FromString/HookClass.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Unit\DataModel\FromString;
+
+use Zerotoprod\DataModel\DataModel;
+use Zerotoprod\DataModel\Describe;
+
+class HookClass
+{
+    use DataModel;
+
+    public static int $pre_called = 0;
+    public static int $post_called = 0;
+
+    #[Describe(['pre' => [self::class, 'preHook'], 'nullable' => true])]
+    public ?string $pre_prop;
+
+    #[Describe(['post' => [self::class, 'postHook'], 'default' => 'value'])]
+    public string $post_prop;
+
+    public static function preHook(mixed $value, array $context, ?\ReflectionAttribute $Attribute, \ReflectionProperty $Property): void
+    {
+        self::$pre_called++;
+    }
+
+    public static function postHook(mixed $value, array $context, ?\ReflectionAttribute $Attribute, \ReflectionProperty $Property): void
+    {
+        self::$post_called++;
+    }
+}

--- a/tests/Unit/DataModel/FromString/RequiredClass.php
+++ b/tests/Unit/DataModel/FromString/RequiredClass.php
@@ -5,7 +5,7 @@ namespace Tests\Unit\DataModel\FromString;
 use Zerotoprod\DataModel\DataModel;
 use Zerotoprod\DataModel\Describe;
 
-readonly class RequiredClass
+class RequiredClass
 {
     use DataModel;
 

--- a/tests/Unit/DataModel/FromString/RequiredClass.php
+++ b/tests/Unit/DataModel/FromString/RequiredClass.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tests\Unit\DataModel\FromString;
+
+use Zerotoprod\DataModel\DataModel;
+use Zerotoprod\DataModel\Describe;
+
+readonly class RequiredClass
+{
+    use DataModel;
+
+    #[Describe(['required' => true])]
+    public string $required_prop;
+}

--- a/tests/Unit/Describe/SubclassDescribe/BaseClass.php
+++ b/tests/Unit/Describe/SubclassDescribe/BaseClass.php
@@ -4,7 +4,7 @@ namespace Tests\Unit\Describe\SubclassDescribe;
 
 use Zerotoprod\DataModel\DataModel;
 
-readonly class BaseClass
+class BaseClass
 {
     use DataModel;
 
@@ -14,9 +14,25 @@ readonly class BaseClass
     #[ChildDescribe(['default' => 'fallback'])]
     public string $default_prop;
 
+    #[ChildDescribe(['default' => [self::class, 'defaultCallable']])]
+    public string $default_callable_prop;
+
     #[ChildDescribe(['assign' => 'fixed'])]
     public string $assign_prop;
 
+    #[ChildDescribe(['assign' => [self::class, 'assignCallable']])]
+    public string $assign_callable_prop;
+
     #[ChildDescribe(['ignore' => true])]
     public string $ignored_prop;
+
+    public static function defaultCallable(): string
+    {
+        return 'callable_default';
+    }
+
+    public static function assignCallable(): string
+    {
+        return 'callable_assign';
+    }
 }

--- a/tests/Unit/Describe/SubclassDescribe/BaseClass.php
+++ b/tests/Unit/Describe/SubclassDescribe/BaseClass.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests\Unit\Describe\SubclassDescribe;
+
+use Zerotoprod\DataModel\DataModel;
+
+readonly class BaseClass
+{
+    use DataModel;
+
+    #[ChildDescribe(['nullable' => true])]
+    public ?string $nullable_prop;
+
+    #[ChildDescribe(['default' => 'fallback'])]
+    public string $default_prop;
+
+    #[ChildDescribe(['assign' => 'fixed'])]
+    public string $assign_prop;
+
+    #[ChildDescribe(['ignore' => true])]
+    public string $ignored_prop;
+}

--- a/tests/Unit/Describe/SubclassDescribe/Child.php
+++ b/tests/Unit/Describe/SubclassDescribe/Child.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Tests\Unit\Describe\SubclassDescribe;
+
+class Child
+{
+    public function __construct(public readonly string $value) {}
+
+    public static function create(array $context): self
+    {
+        return new self($context['value']);
+    }
+}

--- a/tests/Unit/Describe/SubclassDescribe/ChildDescribe.php
+++ b/tests/Unit/Describe/SubclassDescribe/ChildDescribe.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Tests\Unit\Describe\SubclassDescribe;
+
+use Attribute;
+use Zerotoprod\DataModel\Describe;
+
+#[Attribute]
+class ChildDescribe extends Describe {}

--- a/tests/Unit/Describe/SubclassDescribe/ClassLevelCast.php
+++ b/tests/Unit/Describe/SubclassDescribe/ClassLevelCast.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Unit\Describe\SubclassDescribe;
+
+use Zerotoprod\DataModel\DataModel;
+
+#[ChildDescribe(['cast' => ['string' => [self::class, 'upper']]])]
+class ClassLevelCast
+{
+    use DataModel;
+
+    public string $name;
+
+    public static function upper(mixed $value, array $context): string
+    {
+        return strtoupper($value);
+    }
+}

--- a/tests/Unit/Describe/SubclassDescribe/ClassNullable.php
+++ b/tests/Unit/Describe/SubclassDescribe/ClassNullable.php
@@ -5,7 +5,7 @@ namespace Tests\Unit\Describe\SubclassDescribe;
 use Zerotoprod\DataModel\DataModel;
 
 #[ChildDescribe(['nullable' => true])]
-readonly class ClassNullable
+class ClassNullable
 {
     use DataModel;
 

--- a/tests/Unit/Describe/SubclassDescribe/ClassNullable.php
+++ b/tests/Unit/Describe/SubclassDescribe/ClassNullable.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tests\Unit\Describe\SubclassDescribe;
+
+use Zerotoprod\DataModel\DataModel;
+
+#[ChildDescribe(['nullable' => true])]
+readonly class ClassNullable
+{
+    use DataModel;
+
+    public ?string $name;
+    public ?int $age;
+}

--- a/tests/Unit/Describe/SubclassDescribe/ContextClass.php
+++ b/tests/Unit/Describe/SubclassDescribe/ContextClass.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Unit\Describe\SubclassDescribe;
+
+use Zerotoprod\DataModel\DataModel;
+
+class ContextClass
+{
+    use DataModel;
+
+    #[ChildDescribe(['from' => 'remapped_key'])]
+    public string $from_prop;
+
+    #[ChildDescribe(['cast' => [self::class, 'castUpper']])]
+    public string $cast_prop;
+
+    #[ChildDescribe(['cast' => [self::class, 'castWithContext'], 'label' => 'test'])]
+    public string $cast_four_param_prop;
+
+    public static int $pre_called = 0;
+    public static int $post_called = 0;
+
+    #[ChildDescribe(['pre' => [self::class, 'preHook']])]
+    public string $pre_prop;
+
+    #[ChildDescribe(['post' => [self::class, 'postHook']])]
+    public string $post_prop;
+
+    #[ChildDescribe(['via' => [Child::class, 'create']])]
+    public Child $via_prop;
+
+    public static function castUpper(mixed $value): string
+    {
+        return strtoupper($value);
+    }
+
+    public static function castWithContext(mixed $value, array $context, ?\ReflectionAttribute $Attribute, \ReflectionProperty $Property): string
+    {
+        $extra = $Attribute->newInstance()->extra;
+
+        return $value.'-'.$extra['label'];
+    }
+
+    public static function preHook(mixed $value, array $context, ?\ReflectionAttribute $Attribute, \ReflectionProperty $Property): void
+    {
+        self::$pre_called++;
+    }
+
+    public static function postHook(mixed $value, array $context, ?\ReflectionAttribute $Attribute, \ReflectionProperty $Property): void
+    {
+        self::$post_called++;
+    }
+}

--- a/tests/Unit/Describe/SubclassDescribe/MethodLevelClass.php
+++ b/tests/Unit/Describe/SubclassDescribe/MethodLevelClass.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Unit\Describe\SubclassDescribe;
+
+use Zerotoprod\DataModel\DataModel;
+
+class MethodLevelClass
+{
+    use DataModel;
+
+    public string $name;
+
+    #[ChildDescribe('name')]
+    public function resolveName(mixed $value, array $context, ?\ReflectionAttribute $Attribute, \ReflectionProperty $Property): string
+    {
+        return strtoupper($value);
+    }
+}

--- a/tests/Unit/Describe/SubclassDescribe/RequiredClass.php
+++ b/tests/Unit/Describe/SubclassDescribe/RequiredClass.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Tests\Unit\Describe\SubclassDescribe;
+
+use Zerotoprod\DataModel\DataModel;
+
+readonly class RequiredClass
+{
+    use DataModel;
+
+    #[ChildDescribe(['required' => true])]
+    public string $required_prop;
+}

--- a/tests/Unit/Describe/SubclassDescribe/RequiredClass.php
+++ b/tests/Unit/Describe/SubclassDescribe/RequiredClass.php
@@ -4,7 +4,7 @@ namespace Tests\Unit\Describe\SubclassDescribe;
 
 use Zerotoprod\DataModel\DataModel;
 
-readonly class RequiredClass
+class RequiredClass
 {
     use DataModel;
 

--- a/tests/Unit/Describe/SubclassDescribe/SubclassDescribeTest.php
+++ b/tests/Unit/Describe/SubclassDescribe/SubclassDescribeTest.php
@@ -4,9 +4,12 @@ namespace Tests\Unit\Describe\SubclassDescribe;
 
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
+use Zerotoprod\DataModel\PropertyRequiredException;
 
 class SubclassDescribeTest extends TestCase
 {
+    /* ── No-context tests (from() / from('')) ── */
+
     #[Test] public function nullable_set_to_null_with_no_context(): void
     {
         $BaseClass = BaseClass::from();
@@ -21,11 +24,25 @@ class SubclassDescribeTest extends TestCase
         self::assertEquals('fallback', $BaseClass->default_prop);
     }
 
+    #[Test] public function default_callable_applied_with_no_context(): void
+    {
+        $BaseClass = BaseClass::from();
+
+        self::assertEquals('callable_default', $BaseClass->default_callable_prop);
+    }
+
     #[Test] public function assign_applied_with_no_context(): void
     {
         $BaseClass = BaseClass::from();
 
         self::assertEquals('fixed', $BaseClass->assign_prop);
+    }
+
+    #[Test] public function assign_callable_applied_with_no_context(): void
+    {
+        $BaseClass = BaseClass::from();
+
+        self::assertEquals('callable_assign', $BaseClass->assign_callable_prop);
     }
 
     #[Test] public function ignored_property_not_initialized(): void
@@ -54,6 +71,121 @@ class SubclassDescribeTest extends TestCase
         $BaseClass = BaseClass::from('');
 
         self::assertEquals('fixed', $BaseClass->assign_prop);
+    }
+
+    /* ── Context-dependent tests ── */
+
+    #[Test] public function from_remaps_key(): void
+    {
+        $obj = ContextClass::from([
+            'remapped_key' => 'remapped_value',
+            'cast_prop' => 'hello',
+            'cast_four_param_prop' => 'hello',
+            'pre_prop' => 'x',
+            'post_prop' => 'x',
+            'via_prop' => ['value' => 'v'],
+        ]);
+
+        self::assertEquals('remapped_value', $obj->from_prop);
+    }
+
+    #[Test] public function cast_single_param(): void
+    {
+        $obj = ContextClass::from([
+            'cast_prop' => 'hello',
+            'cast_four_param_prop' => 'hello',
+            'pre_prop' => 'x',
+            'post_prop' => 'x',
+            'via_prop' => ['value' => 'v'],
+        ]);
+
+        self::assertEquals('HELLO', $obj->cast_prop);
+    }
+
+    #[Test] public function cast_four_params_with_extra(): void
+    {
+        $obj = ContextClass::from([
+            'cast_prop' => 'hello',
+            'cast_four_param_prop' => 'hello',
+            'pre_prop' => 'x',
+            'post_prop' => 'x',
+            'via_prop' => ['value' => 'v'],
+        ]);
+
+        self::assertEquals('hello-test', $obj->cast_four_param_prop);
+    }
+
+    #[Test] public function pre_hook_fires(): void
+    {
+        ContextClass::$pre_called = 0;
+
+        ContextClass::from([
+            'cast_prop' => 'a',
+            'cast_four_param_prop' => 'a',
+            'pre_prop' => 'x',
+            'post_prop' => 'x',
+            'via_prop' => ['value' => 'v'],
+        ]);
+
+        self::assertEquals(1, ContextClass::$pre_called);
+    }
+
+    #[Test] public function post_hook_fires(): void
+    {
+        ContextClass::$post_called = 0;
+
+        ContextClass::from([
+            'cast_prop' => 'a',
+            'cast_four_param_prop' => 'a',
+            'pre_prop' => 'x',
+            'post_prop' => 'x',
+            'via_prop' => ['value' => 'v'],
+        ]);
+
+        self::assertEquals(1, ContextClass::$post_called);
+    }
+
+    #[Test] public function via_custom_instantiation(): void
+    {
+        $obj = ContextClass::from([
+            'cast_prop' => 'a',
+            'cast_four_param_prop' => 'a',
+            'pre_prop' => 'x',
+            'post_prop' => 'x',
+            'via_prop' => ['value' => 'hello'],
+        ]);
+
+        self::assertInstanceOf(Child::class, $obj->via_prop);
+        self::assertEquals('hello', $obj->via_prop->value);
+    }
+
+    #[Test] public function required_throws(): void
+    {
+        $this->expectException(PropertyRequiredException::class);
+
+        RequiredClass::from([]);
+    }
+
+    #[Test] public function class_level_nullable(): void
+    {
+        $obj = ClassNullable::from();
+
+        self::assertNull($obj->name);
+        self::assertNull($obj->age);
+    }
+
+    #[Test] public function class_level_cast(): void
+    {
+        $obj = ClassLevelCast::from(['name' => 'hello']);
+
+        self::assertEquals('HELLO', $obj->name);
+    }
+
+    #[Test] public function method_level_describe(): void
+    {
+        $obj = MethodLevelClass::from(['name' => 'hello']);
+
+        self::assertEquals('HELLO', $obj->name);
     }
 
     #[Test] public function context_values_override_defaults(): void

--- a/tests/Unit/Describe/SubclassDescribe/SubclassDescribeTest.php
+++ b/tests/Unit/Describe/SubclassDescribe/SubclassDescribeTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Unit\Describe\SubclassDescribe;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class SubclassDescribeTest extends TestCase
+{
+    #[Test] public function nullable_set_to_null_with_no_context(): void
+    {
+        $BaseClass = BaseClass::from();
+
+        self::assertNull($BaseClass->nullable_prop);
+    }
+
+    #[Test] public function default_applied_with_no_context(): void
+    {
+        $BaseClass = BaseClass::from();
+
+        self::assertEquals('fallback', $BaseClass->default_prop);
+    }
+
+    #[Test] public function assign_applied_with_no_context(): void
+    {
+        $BaseClass = BaseClass::from();
+
+        self::assertEquals('fixed', $BaseClass->assign_prop);
+    }
+
+    #[Test] public function ignored_property_not_initialized(): void
+    {
+        $BaseClass = BaseClass::from();
+
+        self::assertFalse(isset($BaseClass->ignored_prop));
+    }
+
+    #[Test] public function nullable_set_to_null_with_string_context(): void
+    {
+        $BaseClass = BaseClass::from('');
+
+        self::assertNull($BaseClass->nullable_prop);
+    }
+
+    #[Test] public function default_applied_with_string_context(): void
+    {
+        $BaseClass = BaseClass::from('');
+
+        self::assertEquals('fallback', $BaseClass->default_prop);
+    }
+
+    #[Test] public function assign_applied_with_string_context(): void
+    {
+        $BaseClass = BaseClass::from('');
+
+        self::assertEquals('fixed', $BaseClass->assign_prop);
+    }
+
+    #[Test] public function context_values_override_defaults(): void
+    {
+        $BaseClass = BaseClass::from([
+            'nullable_prop' => 'present',
+            'default_prop' => 'override',
+        ]);
+
+        self::assertEquals('present', $BaseClass->nullable_prop);
+        self::assertEquals('override', $BaseClass->default_prop);
+        self::assertEquals('fixed', $BaseClass->assign_prop);
+    }
+}


### PR DESCRIPTION
## Description
Support subclassing Describe and treat string context as empty

- Add IS_INSTANCEOF flag to Describe attribute lookups to recognize subclasses
- Treat string context as empty array so attribute defaults (default, assign, nullable) still apply
- Add documentation for subclassing Describe and string context behavior
- Update docblocks to clarify string context handling